### PR TITLE
Fixed original-order bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ng-isotope
 
 AngularJS directives for Isotope by Metafizzy
 
-Using current isotope available v2.0.0-beta.8 and Angular 1.2.10
+Using current isotope available v2.0.0-beta.8 and Angular 1.2.14
 
 This is a working in progress. Pull requests are welcome.
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-isotope",
   "main": ["ng-isotope.js", "isotope.pkgd.js"],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/diego-vieira/ng-isotope",
   "authors": [
     "Diego Vieira <diego@protos.inf.br>"

--- a/demo.html
+++ b/demo.html
@@ -2,10 +2,10 @@
 <html ng-app="isotopeDemo">
 <head>
     <title>ng-isotope demo</title>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/bootstrap/3.1.0/css/bootstrap.css"/>
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="demo.css"/>
-    <script src="//cdn.jsdelivr.net/jquery/2.1.0/jquery.min.js"></script>
-    <script src="//cdn.jsdelivr.net/angularjs/1.2.10/angular.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular.min.js"></script>
     <script src="isotope.pkgd.js"></script>
     <script src="ng-isotope.js"></script>
     <script>
@@ -232,7 +232,7 @@
     <legend>Sort</legend>
 
     <div class="btn-group" isotope-sort isotope-sort-event="sort-elements">
-        <button isotope-sort-by="originalorder" class="btn btn-default active">original order</button>
+        <button isotope-sort-by="original-order" class="btn btn-default active">original order</button>
         <button isotope-sort-by="name" class="btn btn-default">name</button>
         <button isotope-sort-by="symbol" class="btn btn-default">symbol</button>
         <button isotope-sort-by="number" class="btn btn-default">number</button>

--- a/ng-isotope.js
+++ b/ng-isotope.js
@@ -1,5 +1,5 @@
 /**
- * ng-isotope v0.0.1
+ * ng-isotope v0.0.2
  * AngularJS directives for Isotope by Metafizzy
  * http://isotope.metafizzy.co
 


### PR DESCRIPTION
Hi Diego,

Thank you so much for this! I needed this for a project and am working on implementing it now. 

I noticed a bug with the "original order" button and fixed it (just changed "originalorder" to "original-order", this can also be left blank, i.e. ""). While I was in there I also updated AngularJS and bumped the version number.

Thanks again for your awesome work!

Ryan

Change log:
- Fixed original-order (originalorder) bug in demo.html
- Updated AngularJS from 1.2.10 to 1.2.14 using Google CDN (jsdelivr's latest is only 1.2.10)
- Changed jQuery to Google CDN (since it's also being used for AngularJS)
- Updated Bootstrap CSS to 3.1.1 minified using Bootstrap CDN
- Updated bower.json and ng-isotope.js to v0.0.2
